### PR TITLE
Accept recurrence-set with master in any position

### DIFF
--- a/src/icalendar_searcher/searcher.py
+++ b/src/icalendar_searcher/searcher.py
@@ -831,11 +831,16 @@ class Searcher(FilterMixin):
 
         2.1) All components in the recurrence set should have the same UID
 
-        2.2) First element ("master") of the recurrence set may have the RRULE
-        property set
+        2.2) Exactly one element ("master") of the recurrence set may
+        have the RRULE property set.  RFC 5545 does not mandate any
+        particular ordering inside a VCALENDAR, so the master may
+        appear in any position; this method will move it to the head
+        of the returned list so downstream expansion code can rely on
+        ``components[0]`` being the master.
 
-        2.3) Any following elements of a recurrence set ("exception
-        recurrences") should have the RECURRENCE-ID property set.
+        2.3) Any non-master elements of a recurrence set ("exception
+        recurrences") should have the RECURRENCE-ID property set and
+        must not have RRULE.
 
         2.4) (there are more properties that may only be set in the
         master or only in the recurrences, but currently we don't do
@@ -853,25 +858,38 @@ class Searcher(FilterMixin):
         ## We shouldn't get here.  There should always be a valid component.
         if not len(components):
             raise ValueError("Empty component?")
-        first = components[0]
 
-        ## A recurrence set should always be one "master" with
-        ## rrule-id set, followed by zero or more objects without
-        ## rrule-id but with recurrence-id set
+        ## A recurrence set should be exactly one "master" (with RRULE) plus zero
+        ## or more "exception recurrences" (with RECURRENCE-ID and without RRULE),
+        ## OR zero masters plus one-or-more standalone occurrences (all with
+        ## RECURRENCE-ID).  RFC 5545 does not mandate an ordering inside the
+        ## VCALENDAR, so we accept the master in any position and reorder it to
+        ## the head.  Some servers (notably calendar.mail.ru) emit overrides
+        ## before the master.
         if len(components) > 1:
-            if (
-                ("RRULE" not in components[0] and "RECURRENCE-ID" not in components[0])
-                or not all("recurrence-id" in x for x in components[1:])
-                or any("RRULE" in x for x in components[1:])
-            ):
+            masters = [c for c in components if "RRULE" in c and "RECURRENCE-ID" not in c]
+            non_masters = [c for c in components if c not in masters]
+            if len(masters) > 1 or any("RRULE" in c for c in non_masters):
                 raise ValueError(
                     "Expected a valid recurrence set, either with one master component followed with special recurrences or with only occurrences"
                 )
+            if masters:
+                if not all("RECURRENCE-ID" in c for c in non_masters):
+                    raise ValueError(
+                        "Expected a valid recurrence set, either with one master component followed with special recurrences or with only occurrences"
+                    )
+                components = masters + non_masters
+            else:
+                if not all("RECURRENCE-ID" in c for c in non_masters):
+                    raise ValueError(
+                        "Expected a valid recurrence set, either with one master component followed with special recurrences or with only occurrences"
+                    )
 
         ## components should typically be a list with only one component.
         ## if there are more components, it should be a recurrence set
         ## one of the things identifying a recurrence set is that the
         ## uid is the same for all components in the set
+        first = components[0]
         if any(x for x in components if x["uid"] != first["uid"]):
             raise ValueError(
                 "Input parameter component is supposed to contain a single component or a recurrence set - but multiple UIDs found"

--- a/tests/test_validate_and_normalize_component.py
+++ b/tests/test_validate_and_normalize_component.py
@@ -402,3 +402,81 @@ def test_validate_all_same_component_type_same_uid_without_recurrence() -> None:
     # This should raise ValueError because first component lacks RRULE
     with pytest.raises(ValueError, match="valid recurrence set"):
         searcher._validate_and_normalize_component(cal)
+
+
+def test_validate_recurrence_set_master_after_exception() -> None:
+    """Master may appear after the exception in the VCALENDAR.
+
+    RFC 5545 does not mandate any particular ordering of VEVENT components
+    inside a VCALENDAR.  Some CalDAV servers (notably ``calendar.mail.ru``)
+    return overrides before the master in the .ics they hand out, which used
+    to make ``_validate_and_normalize_component`` raise.  The normalized list
+    must put the master first so that the downstream expansion code can rely
+    on ``components[0]`` being the master.
+    """
+    cal = Calendar()
+
+    # Exception event first (mail.ru-style ordering)
+    exception = Event()
+    exception.add("uid", "recurring-meeting")
+    exception.add("summary", "Special Meeting")
+    exception.add("dtstart", datetime(2025, 1, 13, 14, 0))
+    exception.add("dtend", datetime(2025, 1, 13, 15, 0))
+    exception.add("recurrence-id", datetime(2025, 1, 13, 10, 0))
+    cal.add_component(exception)
+
+    # Master event with RRULE last
+    master = Event()
+    master.add("uid", "recurring-meeting")
+    master.add("summary", "Weekly Meeting")
+    master.add("dtstart", datetime(2025, 1, 6, 10, 0))
+    master.add("dtend", datetime(2025, 1, 6, 11, 0))
+    master.add("rrule", vRecur(FREQ="WEEKLY", COUNT=4))
+    cal.add_component(master)
+
+    searcher = Searcher()
+    result = searcher._validate_and_normalize_component(cal)
+
+    assert len(result) == 2, "Should contain master and exception"
+    assert "rrule" in result[0], "Master must be reordered to position 0"
+    assert "recurrence-id" not in result[0], "Master must not carry RECURRENCE-ID"
+    assert "recurrence-id" in result[1], "Exception must follow the master"
+    assert "rrule" not in result[1], "Exception must not carry RRULE"
+
+
+def test_validate_recurrence_set_master_in_middle() -> None:
+    """Master may appear between exceptions in arbitrary order."""
+    cal = Calendar()
+
+    exception1 = Event()
+    exception1.add("uid", "meeting")
+    exception1.add("summary", "First override")
+    exception1.add("dtstart", datetime(2025, 1, 13, 14, 0))
+    exception1.add("dtend", datetime(2025, 1, 13, 15, 0))
+    exception1.add("recurrence-id", datetime(2025, 1, 13, 10, 0))
+    cal.add_component(exception1)
+
+    master = Event()
+    master.add("uid", "meeting")
+    master.add("summary", "Weekly Meeting")
+    master.add("dtstart", datetime(2025, 1, 6, 10, 0))
+    master.add("dtend", datetime(2025, 1, 6, 11, 0))
+    master.add("rrule", vRecur(FREQ="WEEKLY", COUNT=10))
+    cal.add_component(master)
+
+    exception2 = Event()
+    exception2.add("uid", "meeting")
+    exception2.add("summary", "Second override")
+    exception2.add("dtstart", datetime(2025, 1, 20, 14, 0))
+    exception2.add("dtend", datetime(2025, 1, 20, 15, 0))
+    exception2.add("recurrence-id", datetime(2025, 1, 20, 10, 0))
+    cal.add_component(exception2)
+
+    searcher = Searcher()
+    result = searcher._validate_and_normalize_component(cal)
+
+    assert len(result) == 3, "Should contain master and both exceptions"
+    assert "rrule" in result[0], "Master must be reordered to position 0"
+    assert all("recurrence-id" in c for c in result[1:]), (
+        "All non-master components must carry RECURRENCE-ID"
+    )


### PR DESCRIPTION
## Summary

RFC 5545 does not mandate that the master `VEVENT` (the one carrying the `RRULE`) appears first inside a `VCALENDAR`. Some CalDAV servers — most notably `calendar.mail.ru`, and a few corporate Exchange/CalDAV front-ends I have run into — emit the override `VEVENT`s (those with `RECURRENCE-ID`) **before** the master in the `.ics` they return.

Today `Searcher._validate_and_normalize_component` rejects such recurrence sets:

```python
if (
    ("RRULE" not in components[0] and "RECURRENCE-ID" not in components[0])
    or not all("recurrence-id" in x for x in components[1:])
    or any("RRULE" in x for x in components[1:])
):
    raise ValueError(
        "Expected a valid recurrence set, either with one master component followed with special recurrences or with only occurrences"
    )
```

`caldav._filter_search_results` then swallows this `ValueError` and returns the raw subcomponents without expanding the `RRULE`, which silently drops every regular instance of the series — only the master `DTSTART` and the explicit overrides survive. From the user's point of view, future occurrences of a recurring meeting disappear from search results.

## Reproducer (real `.ics` returned by `calendar.mail.ru`)

```ics
BEGIN:VCALENDAR
VERSION:2.0
PRODID:-//MailRu//MailRu Calendar API -//EN
BEGIN:VTIMEZONE
TZID:Europe/Moscow
...
END:VTIMEZONE
BEGIN:VEVENT
UID:EBDF951F-16D9-49A2-9308-ED163E3C0E08
SUMMARY:Product review
DTSTART;TZID=Europe/Moscow:20260521T163000
DTEND;TZID=Europe/Moscow:20260521T170000
RECURRENCE-ID:20260521T133000Z
END:VEVENT
BEGIN:VEVENT
UID:EBDF951F-16D9-49A2-9308-ED163E3C0E08
SUMMARY:Product review
DTSTART;TZID=Europe/Moscow:20260514T143000
DTEND;TZID=Europe/Moscow:20260514T150000
RECURRENCE-ID:20260514T133000Z
END:VEVENT
BEGIN:VEVENT
UID:EBDF951F-16D9-49A2-9308-ED163E3C0E08
SUMMARY:Product review
DTSTART;TZID=Europe/Moscow:20260416T163000
DTEND;TZID=Europe/Moscow:20260416T170000
RRULE:FREQ=WEEKLY;BYDAY=TH
EXDATE:20260423T133000Z,20260507T133000Z
END:VEVENT
END:VCALENDAR
```

`search_calendar(..., expand=True)` against this returns 3 components (master + two overrides) instead of the ~12 expanded weekly instances inside a 4-month window.

## Fix

Make the validation in `_validate_and_normalize_component` order-independent:

1. Locate the master = the component with `RRULE` and without `RECURRENCE-ID`.
2. Reject the set if there is more than one such master, or if any non-master carries an `RRULE`, or if any non-master lacks a `RECURRENCE-ID`.
3. Otherwise reorder the list so the master sits at position `0` and the overrides follow, so that downstream expansion code can keep its assumption that `components[0]` is the master.

All previous invariants (single `UID`, exactly one master, exceptions carry `RECURRENCE-ID` without `RRULE`) are preserved — only the **positional** requirement is relaxed. The error path for genuinely invalid recurrence sets still raises the same `ValueError` with the same message.

## Tests

* Existing test suite: **204 passed, 7 skipped** locally, no regressions.
* Two new tests in `tests/test_validate_and_normalize_component.py`:
  * `test_validate_recurrence_set_master_after_exception` — mail.ru-style ordering (override first, master last).
  * `test_validate_recurrence_set_master_in_middle` — master between two overrides.

Happy to iterate on the error message wording or the docstring if you'd prefer a different phrasing.